### PR TITLE
Add missing buildtool_depend on git

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
   <license>Mozilla Public License 2.0</license> <!-- sol2 is MPLv2 -->
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <depend>libzmq3-dev</depend>
 


### PR DESCRIPTION
This vendor package requires `git` to download the `zmqpp` sources during the build, so it should declare a buildtool dependency on it.