### PR TITLE
fix default branch name

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: ${{ steps.create_release.outputs.created_branch }}
-          destination_branch: master
+          destination_branch: main
           pr_title: Release ${{ steps.create_release.outputs.version}}
           pr_body: close \#${{ github.event.issue.number }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: MasayaKataoka <ms.kataoka@gmail.com>

fix default branch name in release action.